### PR TITLE
Adiciona botão flutuante "Ir para o topo"

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -7,6 +7,7 @@
 		<meta name="description" content="Centro do Opus Dei para homens em São José dos Campos, São Paulo, Brasil.">
 		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
 		<link rel="stylesheet" href="{{page.baseurl}}assets/css/main.css" />
+		<link rel="stylesheet" href="{{page.baseurl}}assets/css/custom.css" />
 
 		<!-- jQuery 1.8 or later, 33 KB -->
 		<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
@@ -68,6 +69,10 @@
 					</div>
 				</div>
 
+				<div class="button-top" id="js-button-top">
+					<img src="../assets/images/chevron-up-solid.svg" alt="Ícone de seta para cima">
+				</div>
+
 			<!-- Sidebar -->
 			{% include sidebar.html %}
 
@@ -79,6 +84,7 @@
 		<script src="{{page.baseurl}}assets/js/breakpoints.min.js"></script>
 		<script src="{{page.baseurl}}assets/js/util.js"></script>
 		<script src="{{page.baseurl}}assets/js/main.js"></script>
+		<script src="{{page.baseurl}}assets/js/custom.js"></script>
 
 	</body>
 </html>

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -1,0 +1,37 @@
+/*
+    CSS que adiciona novos estilos (diferentes do template HTML UP)
+ */
+.button-top {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    background-color: #7f1416;
+    border-radius: 5px;
+    position: fixed;
+    height: 50px;
+    width: 50px;
+    bottom: 30px;
+    right: 30px;
+    transform: translateX(100px);
+    color: #ffffff;
+    cursor: pointer;
+    user-select: none;
+    box-shadow:
+        0 3px 6px rgb(0 0 0 / 16%),
+        0 3px 6px rgb(0 0 0 / 23%);
+}
+
+    .button-top > img {
+        width: 20px;
+    }
+
+    .button-top.is-visible {
+        transform: translateX(0);
+    }
+
+    @media (max-width: 480px) {
+        .button-top  {
+            bottom: 10px;
+            right: 10px;
+        }
+    }

--- a/assets/images/chevron-up-solid.svg
+++ b/assets/images/chevron-up-solid.svg
@@ -1,0 +1,15 @@
+<svg
+    aria-hidden="true"
+    focusable="false"
+    data-prefix="fas"
+    data-icon="chevron-up"
+    class="svg-inline--fa
+    fa-chevron-up
+    fa-w-14"
+    role="img"
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 448 512"
+    fill="#ffffff"
+>
+    <path fill="#ffffff" d="M240.971 130.524l194.343 194.343c9.373 9.373 9.373 24.569 0 33.941l-22.667 22.667c-9.357 9.357-24.522 9.375-33.901.04L224 227.495 69.255 381.516c-9.379 9.335-24.544 9.317-33.901-.04l-22.667-22.667c-9.373-9.373-9.373-24.569 0-33.941L207.03 130.525c9.372-9.373 24.568-9.373 33.941-.001z"></path>
+</svg>

--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -1,0 +1,23 @@
+/*
+	JavaScript que customiza algumas funcionalidades do template do HTML5 UP.
+*/
+(function($) {
+
+	var	$window = $(window),
+        $buttonTop = $('#js-button-top');
+
+
+	// Botão "Ir para o topo"
+        $buttonTop.on('click', function() {
+            $('html, body').animate({ scrollTop: 0 }, '300');
+        });
+
+        $window.scroll(function() {
+            if (window.scrollY > 600) {
+                $('#js-button-top').addClass('is-visible');
+            } else {
+                $('#js-button-top').removeClass('is-visible');
+            }
+        });
+
+})(jQuery);


### PR DESCRIPTION
O botão irá aparecer depois que a página tiver rolado pelo menos 600px para baixo. Esse número pode ser modificado se achar que "demora" muito a aparecer.


![button_top_desktop](https://user-images.githubusercontent.com/3102551/113034849-f223f080-9168-11eb-88e0-7cdba78d72c9.gif)
![button_top_mobile](https://user-images.githubusercontent.com/3102551/113034811-ec2e0f80-9168-11eb-939d-5fb152365478.gif)

